### PR TITLE
Allow to get Color from Analysis

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -10,7 +10,6 @@ single_version_file = true
 deprecate_by_min_version = true
 
 generate = [
-    # "Pango.AttrColor",
     # "Pango.AttrFloat",
     # "Pango.AttrFontDesc",
     # "Pango.AttrFontFeatures",
@@ -72,6 +71,7 @@ manual = [
     "GLib.Error",
     "Pango.Analysis",
     "Pango.AttrClass",
+    "Pango.AttrColor",
     "Pango.Language",
     "Pango.Rectangle",
 ]

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -11,7 +11,6 @@ use Font;
 use Gravity;
 use Language;
 use Script;
-use pango_sys::{PangoAttribute, PangoAttrColor, PangoColor};
 
 #[repr(C)]
 pub struct Analysis(pango_sys::PangoAnalysis);

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -4,12 +4,14 @@
 
 use glib::translate::*;
 use pango_sys;
+use Attribute;
 use EngineLang;
 use EngineShape;
 use Font;
 use Gravity;
 use Language;
 use Script;
+use pango_sys::{PangoAttribute, PangoAttrColor, PangoColor};
 
 #[repr(C)]
 pub struct Analysis(pango_sys::PangoAnalysis);
@@ -47,9 +49,11 @@ impl Analysis {
         unsafe { from_glib_none(self.0.language) }
     }
 
-    /*pub fn extra_attrs(&self) -> Vec<LogAttr> {
-        unsafe { from_glib_none_num_as_vec(self.0.extra_attrs) }
-    }*/
+    pub fn extra_attrs(&self) -> Vec<Attribute> {
+        unsafe {
+            FromGlibPtrContainer::from_glib_none(self.0.extra_attrs)
+        }
+    }
 }
 
 #[doc(hidden)]

--- a/src/attr_class.rs
+++ b/src/attr_class.rs
@@ -2,6 +2,8 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
+use AttrType;
+use glib::translate::from_glib;
 use glib::translate::{FromGlibPtrFull, FromGlibPtrNone, Stash, ToGlibPtr};
 use pango_sys;
 
@@ -46,7 +48,14 @@ impl FromGlibPtrFull<*const pango_sys::PangoAttrClass> for AttrClass {
     }
 }
 
+#[derive(Debug)]
 pub struct AttrClass(*mut pango_sys::PangoAttrClass);
+
+impl AttrClass {
+    pub fn get_type(&self) -> AttrType {
+        unsafe{ from_glib((*self.0).type_) }
+    }
+}
 
 impl PartialEq for AttrClass {
     fn eq(&self, other: &AttrClass) -> bool {

--- a/src/attr_class.rs
+++ b/src/attr_class.rs
@@ -53,7 +53,7 @@ pub struct AttrClass(*mut pango_sys::PangoAttrClass);
 
 impl AttrClass {
     pub fn get_type(&self) -> AttrType {
-        unsafe{ from_glib((*self.0).type_) }
+        unsafe { from_glib((*self.0).type_) }
     }
 }
 

--- a/src/attr_color.rs
+++ b/src/attr_color.rs
@@ -1,0 +1,76 @@
+use glib::translate::from_glib_none;
+use glib::translate::from_glib_full;
+use glib::translate::{FromGlibPtrFull, FromGlibPtrNone, Stash, ToGlibPtr};
+use pango_sys;
+use Attribute;
+use Color;
+
+#[doc(hidden)]
+impl<'a> ToGlibPtr<'a, *mut pango_sys::PangoAttrColor> for &'a AttrColor {
+    type Storage = &'a AttrColor;
+
+    fn to_glib_none(&self) -> Stash<'a, *mut pango_sys::PangoAttrColor, Self> {
+        Stash(self.0, *self)
+    }
+}
+
+#[doc(hidden)]
+impl FromGlibPtrNone<*mut pango_sys::PangoAttrColor> for AttrColor {
+    unsafe fn from_glib_none(ptr: *mut pango_sys::PangoAttrColor) -> Self {
+        assert!(!ptr.is_null());
+        AttrColor(ptr)
+    }
+}
+
+#[doc(hidden)]
+impl FromGlibPtrFull<*mut pango_sys::PangoAttrColor> for AttrColor {
+    unsafe fn from_glib_full(ptr: *mut pango_sys::PangoAttrColor) -> Self {
+        assert!(!ptr.is_null());
+        AttrColor(ptr)
+    }
+}
+
+#[doc(hidden)]
+impl FromGlibPtrNone<*const pango_sys::PangoAttrColor> for AttrColor {
+    unsafe fn from_glib_none(ptr: *const pango_sys::PangoAttrColor) -> Self {
+        assert!(!ptr.is_null());
+        AttrColor(ptr as *mut _)
+    }
+}
+
+#[doc(hidden)]
+impl FromGlibPtrFull<*const pango_sys::PangoAttrColor> for AttrColor {
+    unsafe fn from_glib_full(ptr: *const pango_sys::PangoAttrColor) -> Self {
+        assert!(!ptr.is_null());
+        AttrColor(ptr as *mut _)
+    }
+}
+
+#[derive(Debug)]
+pub struct AttrColor(*mut pango_sys::PangoAttrColor);
+
+impl AttrColor {
+    pub fn get_color(&self) -> Color {
+        unsafe {
+            let color: *const pango_sys::PangoColor = &(*self.0).color;
+            from_glib_none(color)
+        }
+    }
+}
+
+impl From<Attribute> for AttrColor {
+    fn from(attribute: Attribute) -> Self {
+        unsafe {
+            let attr_color = std::mem::transmute::<*const pango_sys::PangoAttribute, *const pango_sys::PangoAttrColor>(attribute.to_glib_none().0);
+            from_glib_full(attr_color)
+        }
+    }
+}
+
+impl PartialEq for AttrColor {
+    fn eq(&self, other: &AttrColor) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for AttrColor {}

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,29 @@
+// Copyright 2018, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use glib::translate::*;
+use Color;
+
+impl Color {
+    pub fn red(&self) -> u16 {
+        unsafe {
+            let stash = self.to_glib_none();
+            (*stash.0).red
+        }
+    }
+
+    pub fn green(&self) -> u16 {
+        unsafe {
+            let stash = self.to_glib_none();
+            (*stash.0).green
+        }
+    }
+
+    pub fn blue(&self) -> u16 {
+        unsafe {
+            let stash = self.to_glib_none();
+            (*stash.0).blue
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub use attr_color::AttrColor;
 pub mod attr_iterator;
 pub mod attr_list;
 pub mod attribute;
+pub mod color;
 pub mod font_description;
 mod functions;
 pub mod gravity;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ pub mod analysis;
 pub use analysis::Analysis;
 pub mod attr_class;
 pub use attr_class::AttrClass;
+pub mod attr_color;
+pub use attr_color::AttrColor;
 pub mod attr_iterator;
 pub mod attr_list;
 pub mod attribute;


### PR DESCRIPTION
The idea is to use it like this:
```rust
let attrs = analysis.extra_attrs();
for attr in attrs {
    let class = attr.get_attr_class();
    let attr_type = class.get_type();
    match attr_type {
        AttrType::Foreground => {
            let color_attr = pango::AttrColor::from(attr);
            let color = color_attr.get_color();
            println!("red color {:?}", color.red());
        }
        _ => {}
    }
}
```